### PR TITLE
bin/pass-man: fix working if there are other tombs opened

### DIFF
--- a/bin/pass-man
+++ b/bin/pass-man
@@ -21,7 +21,7 @@ timer=6h
 _usage() {
     cat <<HELP
 
-pass-man v1.3.2
+pass-man v1.3.3
 Written by Sandor Semsey, Copyright (C) 2020, License MIT
 
 Usage: pass-man ACTION [TARGET] [EXTRA]...
@@ -37,7 +37,9 @@ HELP
 ## Check if tomb is opened
 ##########################
 _check-tomb-open() {
-    tomb list >/dev/null 2>&1
+    local tomb
+    tomb=$(basename "${PASSWORD_STORE_TOMB_FILE:-~/.password.tomb}" .tomb)
+    tomb list "${tomb}" >/dev/null 2>&1
 }
 
 ## Open vault


### PR DESCRIPTION
If there's any other tomb opened in the system (other than the password store tomb), `pass-man` thinks it's the tomb for the password store. So it will refuse to open the password store tomb, as it believes it's already open.

This PR fixes this bug.

**Note**: your password store tomb filename (specified in `PASSWORD_STORE_TOMB_FILE` env var) must have the `.tomb` suffix.