### PR TITLE
bin/pass-man: pass extra options to pass open and close also

### DIFF
--- a/bin/pass-man
+++ b/bin/pass-man
@@ -21,7 +21,7 @@ timer=6h
 _usage() {
     cat <<HELP
 
-pass-man v1.3.3
+pass-man v1.4.0
 Written by Sandor Semsey, Copyright (C) 2020, License MIT
 
 Usage: pass-man ACTION [TARGET] [EXTRA]...
@@ -47,7 +47,7 @@ _check-tomb-open() {
 _vault-open() {
     # shellcheck disable=SC2310
     if ! _check-tomb-open; then
-        pass open -f --timer="${timer}"
+        pass open -f --timer="${timer}" "${@}"
 
         if ! _check-tomb-open; then
             error-exit "Failed to open tomb."
@@ -60,7 +60,7 @@ _vault-open() {
 _vault-close() {
     # shellcheck disable=SC2310
     if _check-tomb-open; then
-        pass close
+        pass close "${@}"
 
         if _check-tomb-open; then
             error-exit "Failed to close tomb."
@@ -104,8 +104,8 @@ action="${1:-}"
 
 # Switch action
 case "${action}" in
-    open) _vault-open ;;
-    close) _vault-close ;;
+    open) _vault-open "${@}" ;;
+    close) _vault-close "${@}" ;;
     generate) _vault-generate "${@}" ;;
     retrieve)
         pass_path="${1:-}"

--- a/bin/pass-man
+++ b/bin/pass-man
@@ -6,12 +6,6 @@
 ## which is inside a tomb.         ##
 #####################################
 
-############
-## CONFIG ##
-############
-# Timer to close tomb automatically
-timer=6h
-
 ###############
 ## FUNCTIONS ##
 ###############
@@ -47,7 +41,7 @@ _check-tomb-open() {
 _vault-open() {
     # shellcheck disable=SC2310
     if ! _check-tomb-open; then
-        pass open -f --timer="${timer}" "${@}"
+        pass open "${@}"
 
         if ! _check-tomb-open; then
             error-exit "Failed to open tomb."


### PR DESCRIPTION
Additionally don't set `-f` and `--time=6h` on `pass open` by default. They can be passed as extra arguments to `pass-man open` to achieve same results.
```
pass-man open -f --timer=6h
```

This allows for more flexibility.