### PR TITLE
bin/backup: v3.0.0 use zstd compression

### DIFF
--- a/bin/backup
+++ b/bin/backup
@@ -6,7 +6,7 @@
 ## Modes:                                    ##
 ##   A) archive                              ##
 ##      1. Backup (rsync)                    ##
-##      2. Archive (tar & gzip)              ##
+##      2. Archive (tar & zstd)              ##
 ##      3. Delete old archives (find)        ##
 ##   B) quick (rsync)                        ##
 ##   C) snapshot (rsync snapshot style)      ##
@@ -20,7 +20,7 @@
 ##########
 _version() {
     cat <<VERSION
-backup v2.5.2
+backup v3.0.0
 Written by Sandor Semsey, Copyright (C) 2020, License MIT
 VERSION
 }
@@ -237,7 +237,7 @@ case "${backup_mode}" in
         fi
 
         print-status Compress files...
-        tar -C "${destination}" -I "pigz --fast" --sort=name -cf "${destination}/${archive_dir}/${archive_prefix}${now}.tar.gz" actual/
+        tar -C "${destination}" -I "zstd -3 --threads=0" --sort=name -cf "${destination}/${archive_dir}/${archive_prefix}${now}.tar.zst" actual/
         print-finish
 
         if [[ -n "${expire_date}" ]]; then

--- a/docs/bin.md
+++ b/docs/bin.md
@@ -8,14 +8,13 @@ Various scripts that can be used as "binaries".
 
 A wrapper for `rsync`.
 Backups source directory to a different file system (drive) as backing up on the same drive sort of defies the goal of backup.
-In archive mode, backups are compressed to save disk space.
-This compression is done by `pigz` which creates standard `gzip` files but spreads the work over multiple processors and cores when compressing so it can utilize modern hardware.
+In archive mode, backups are compressed to save disk space. This compression is done by multi-threaded `zstd`.
 
 Modes:
 
 - Archive
     1. Copy files to destination dir (`rsync`)
-    1. Create single archive file from backed up files (`tar` & `pigz`)
+    1. Create single archive file from backed up files (`tar` & `zstd`)
     1. Rotate (delete) old archives (`find`)
 - Quick: only copy files to destination.
 - Snapshot: backup only changed files from last backup.


### PR DESCRIPTION
Now `backup` use `zstd` compression instead of `gzip`.
`zstd` is faster and has higher compression ratio, but uses more memory: ~100 MB vs `gzip`'s 6 MB (in my benchmark). Though this shouldn't be an issue on a modern hardware.

Note: the archived file extension when using `--archive` is changed from `.gz` to `.zst`!